### PR TITLE
Add catalog-info.yaml for security inventory

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: happyrobot-python
+  annotations:
+    slack.com/channel: security-alerts
+spec:
+  type: service
+  lifecycle: production
+  owner: security

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: security
+  owner: infra


### PR DESCRIPTION
Adds a minimal Backstage catalog file (`catalog-info.yaml`) with owner, lifecycle, and Slack channel metadata for vulnerability management routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added service catalog configuration to register the application in the internal service registry with production lifecycle status and security team ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->